### PR TITLE
Fixed a major parsing error in DFSL_parser

### DIFF
--- a/cost-model/include/dataflow-specification-language/DFSL_parser.hpp
+++ b/cost-model/include/dataflow-specification-language/DFSL_parser.hpp
@@ -77,8 +77,9 @@ namespace maestro {
 				std::string file_name_;
 				std::ifstream in_file_;
 
-				void ParseError(int line_num) {
+				void ParseError(int line_num, std::string err = "Not reported") {
 					std::cout << "[MAESTRO Parser] Parse error at line number " + std::to_string(line_num) + " in target file " +  file_name_  << std::endl;
+          std::cout << "Error was: " + err << std::endl;
 					exit(-1);
 				}
 		}; // End of class InputParser
@@ -90,7 +91,7 @@ namespace maestro {
 
 				void ParseDFSL(std::shared_ptr<DFA::NeuralNetwork> network) {
 					std::string line;
-					boost::char_separator<char> sep(" ,->():\t;");
+					boost::char_separator<char> sep(" ,->():\t\n\r;");
 					int line_number = 1;
 
 //					network = std::make_shared<DFA::NeuralNetwork>();
@@ -167,7 +168,7 @@ namespace maestro {
                     network->SetName(tkn);
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Network_Identifier");
                   }
 
                   break;
@@ -181,7 +182,7 @@ namespace maestro {
                     state_ = ParserState::Layer_Identifier;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Network_Body: " + tkn);
                   }
                   break;
                 }
@@ -202,7 +203,7 @@ namespace maestro {
                 case ParserState::Layer_Body: {
                   if(tkn == DFSL::brace_close_) {
                     if(curr_layer == nullptr) {
-                      ParseError(line_number);
+                      ParseError(line_number, "curr_layer is nullptr");
                     }
                     curr_layer->SetDimensions(dim_vector);
 
@@ -249,7 +250,7 @@ namespace maestro {
                     state_ = ParserState::Dataflow_Decl;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Layer_Body");
                   }
 
                   break;
@@ -355,7 +356,7 @@ namespace maestro {
                     //TODO
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Unsupported layer type");
                   }
                   state_ = ParserState::Layer_Body;
 
@@ -367,7 +368,7 @@ namespace maestro {
                     state_ = ParserState::Dimension_Body;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Dimension_Dec1");
                   }
                   break;
                 }
@@ -381,7 +382,7 @@ namespace maestro {
                       tmp_name = tkn;
                     }
                     else {
-                      ParseError(line_number);
+                      ParseError(line_number, "Bad token in state Dimension_Body");
                     }
                     state_ = ParserState::Dimension_Size;
                   }
@@ -400,7 +401,7 @@ namespace maestro {
 
 
                   if(size == 0) {
-                    ParseError(line_number);
+                    ParseError(line_number, "Dimension size was 0");
                   }
                   else {
 
@@ -420,7 +421,7 @@ namespace maestro {
                     state_ = ParserState::Dataflow_Body;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Dataflow_Dec1");
                   }
                   break;
                 }
@@ -442,7 +443,7 @@ namespace maestro {
                     state_ = ParserState::Dataflow_ClusterSize;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Dataflow_Body");
                   }
                   break;
                 }
@@ -478,7 +479,7 @@ namespace maestro {
                   }
 
                   if(map_size <= 0) {
-                    ParseError(line_number);
+                    ParseError(line_number, "map_size was <= 0");
                   }
 
                   get_dim_size = false;
@@ -516,7 +517,7 @@ namespace maestro {
                   }
 
                   if(map_offset <= 0) {
-                    ParseError(line_number);
+                    ParseError(line_number, "map_offset was <= 0");
                   }
 
                   get_dim_size = false;
@@ -526,7 +527,7 @@ namespace maestro {
 
                 case ParserState::Dataflow_MapVar: {
                   if(tkn.empty()) {
-                    ParseError(line_number);
+                    ParseError(line_number, "Token was empty in Dataflow_MapVar state");
                   }
 
                   switch(curr_directive_class) {
@@ -539,7 +540,7 @@ namespace maestro {
                     break;
                   }
                   default: {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad curr_directive_class");
                   }
                   }
 
@@ -579,7 +580,7 @@ namespace maestro {
                   }
 
                   if(cluster_size <= 0) {
-                    ParseError(line_number);
+                    ParseError(line_number, "cluster_size was <= 0");
                   }
 
                   get_dim_size = false;
@@ -607,7 +608,7 @@ namespace maestro {
                     state_ = ParserState::Acclerator_Body;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Accelerator_Identifier");
                   }
                   break;
                 }
@@ -623,7 +624,7 @@ namespace maestro {
                     state_ = ParserState::NoC_Identifier;
                   }
                   else {
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Accelerator_Body");
                   }
                   break;
                 }
@@ -634,7 +635,7 @@ namespace maestro {
                   }
                   else {
                     //TODO: Add an error message
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state PE_Identifier");
                   }
                   break;
                 }
@@ -645,7 +646,7 @@ namespace maestro {
                   }
                   else {
                     //TODO: Add an error message
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Buffer_Identifier");
                   }
                   break;
                 }
@@ -676,7 +677,7 @@ namespace maestro {
                       break;
                     }
                     else {
-                      ParseError(line_number);
+                      ParseError(line_number, "Bad token in state PE_Body");
                     }
 
                   break;
@@ -826,7 +827,7 @@ namespace maestro {
                   }
                   else {
                     //TODO: Add an error message
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state NoC_Identifier");
                   }
                   break;
                 }
@@ -848,7 +849,7 @@ namespace maestro {
                   }
                   else {
                     //TODO: Add an error message
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state Noc_Name_Identifier");
                   }
                   break;
                 }
@@ -865,7 +866,7 @@ namespace maestro {
                   }
                   else {
                     //TODO: Add an error message
-                    ParseError(line_number);
+                    ParseError(line_number, "Bad token in state SubNoC_Body");
                   }
                   break;
                 }
@@ -873,7 +874,7 @@ namespace maestro {
                 case ParserState::NoC_BW: {
                   int noc_bw = std::atoi(tkn.c_str());
                   if(noc_bw < 1) {
-                    ParseError(line_number);
+                    ParseError(line_number, "noc_bw was < 1");
                   }
                   else {
                     noc_bandwidth_.push_back(noc_bw);
@@ -885,7 +886,7 @@ namespace maestro {
                 case ParserState::NoC_Latency: {
                   int noc_latency = std::atoi(tkn.c_str());
                   if(noc_latency < 1) {
-                    ParseError(line_number);
+                    ParseError(line_number, "noc_latency was < 1");
                   }
                   else {
                     noc_latency_.push_back(noc_latency);
@@ -895,7 +896,7 @@ namespace maestro {
                 }
 
                 default: {
-                  ParseError(line_number);
+                  ParseError(line_number, "Bad parser state");
                   break;
                 }
 							} // End of switch(state_)


### PR DESCRIPTION
Previous version of DFSL_parser did not consider mapping files containing extra whitespace characters \n and \r, added by some IDEs/OSes. This caused a failing error where the parser would fail to match tokens to anything in the list of string constants. Fixed by adding \n and \r to the list of separation characters. Also added some more descriptive debug printouts to the ParseError calls.